### PR TITLE
Fix cookie conflict

### DIFF
--- a/chronopost.php
+++ b/chronopost.php
@@ -441,8 +441,11 @@ class Chronopost extends CarrierModule
 		// Context fix (it's that easy)
 		Context::getContext()->link = new Link();
 		// Fix context by adding employee
-		$cookie = new Cookie('psAdmin');
-		Context::getContext()->employee = new Employee($cookie->id_employee);
+		if(!Context::getContext()->cookie->exists())
+		{
+			$cookie = new Cookie('psAdmin');
+			Context::getContext()->employee = new Employee($cookie->id_employee);
+		}
 
 		$o = new Order($id_order);
 		$o->shipping_number = $shipping_number;


### PR DESCRIPTION
When an another module call `$this->context->employee->isLoggedBack()` method like in https://github.com/TrogloGeek/prestashop-tggatos-module/blob/RC_3.4.0/tggatos.php#L225, generating PDF delivery is broken and is printing the **Context** object, because `isLoggedBack` check password but the new cookie just created doesn't return `passwd` so `checkPassword` method die :
- https://github.com/PrestaShop/PrestaShop/blob/1.6.0.11/classes/Employee.php#L342
- https://github.com/PrestaShop/PrestaShop/blob/1.6.0.11/classes/Employee.php#L292
