### PR TITLE
Use order_carrier weight instead of cart total weight when dealing wi…

### DIFF
--- a/chronopost.php
+++ b/chronopost.php
@@ -669,16 +669,25 @@ class Chronopost extends CarrierModule
 
 	}
 
+	public static function getOrderCarrierWeight($id_order)
+	{
+		$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+				SELECT `weight`
+				FROM `'._DB_PREFIX_.'order_carrier`
+				WHERE `id_order` = '.(int)$id_order);
+		return (float)($result);
+	}
+
 	public static function minNumberOfPackages($orderid)
 	{
 		$order = new Order($orderid);
 		$nblt = 1;
 
-
-		if ($order->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') > 20 && $order->id_carrier == Configuration::get('CHRONORELAIS_CARRIER_ID'))
-			$nblt = ceil($order->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') / 20);
-		if ($order->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') > 30)
-			$nblt = ceil($order->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') / 30);
+		$w = Chronopost::getOrderCarrierWeight($orderid);
+		if ($w * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') > 20 && $order->id_carrier == Configuration::get('CHRONORELAIS_CARRIER_ID'))
+			$nblt = ceil($w * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') / 20);
+		if ($w * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') > 30)
+			$nblt = ceil($w * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') / 30);
 
 		return $nblt;
 	}

--- a/postSkybill.php
+++ b/postSkybill.php
@@ -11,7 +11,7 @@
 */
 
 if (!defined('_MYDIR_')) define('_MYDIR_', dirname(__FILE__));
-require('../../config/config.inc.php');
+require($_SERVER['DOCUMENT_ROOT'].'/config/config.inc.php');
 
 if (!Tools::getIsset('orderid') && !Tools::getIsset('orders') && !Tools::getIsset('orderid')) die('<h1>Informations de commande non transmises</h1>');
 
@@ -108,8 +108,7 @@ function createLT($orderid, $totalnb = 1, $isReturn = false)
 	$cust = new Customer($o->id_customer);
 
 	// at least 2 skybills for orders >= 30kg
-	$o = new Order($orderid);
-	if ($o->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') >= 30 && $totalnb == 1)
+	if (Chronopost::getOrderCarrierWeight($o->id) * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF') >= 30 && $totalnb == 1)
 	{
 		echo '<script>alert(\'Vous devez générer au moins 2 étiquettes pour les commandes de plus de 30kg\');history.back();</script>';
 		exit();
@@ -290,7 +289,7 @@ function createLT($orderid, $totalnb = 1, $isReturn = false)
 	// weight 0 when multishipping
 	$skybill->weight = 0;
 	// Only 1 skybill, put real weight. 
-	if ($totalnb == 1) $skybill->weight = $o->getTotalWeight() * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF');
+	if ($totalnb == 1) $skybill->weight = Chronopost::getOrderCarrierWeight($o->id) * Configuration::get('CHRONOPOST_GENERAL_WEIGHTCOEF');
 
 	$skybill->weightUnit = 'KGM';
 

--- a/postSkybill.php
+++ b/postSkybill.php
@@ -11,7 +11,7 @@
 */
 
 if (!defined('_MYDIR_')) define('_MYDIR_', dirname(__FILE__));
-require($_SERVER['DOCUMENT_ROOT'].'/config/config.inc.php');
+require('../../config/config.inc.php');
 
 if (!Tools::getIsset('orderid') && !Tools::getIsset('orders') && !Tools::getIsset('orderid')) die('<h1>Informations de commande non transmises</h1>');
 


### PR DESCRIPTION
…th skybill and number of parcels.

Hi, This patch allows inserting gifts in parcels; heavy boxes; product database not having all weight up to date; handmade products with varying weight...

In our production we use this patch along with a module that allows updating order_carrier data. We prepare orders, weight them, update the order_carrier weight and then edit the skybill. This way the parcel weight is always exact.

I tried to make sure this was not affecting dynamic shipping price computation (still relying on products weight sum). Can you double check this?

Happy up-streaming! :)

Thanks,
Fabrice.
